### PR TITLE
add mjs files icon

### DIFF
--- a/plugin/defx_icons.vim
+++ b/plugin/defx_icons.vim
@@ -68,6 +68,7 @@ let s:extensions = extend({
       \ 'rmd': {'icon': '', 'color': s:gui_colors.white, 'term_color': s:term_colors.white},
       \ 'json': {'icon': '', 'color': s:gui_colors.beige, 'term_color': s:term_colors.beige},
       \ 'js': {'icon': '', 'color': s:gui_colors.beige, 'term_color': s:term_colors.beige},
+      \ 'mjs': {'icon': '', 'color': s:gui_colors.beige, 'term_color': s:term_colors.beige},
       \ 'jsx': {'icon': '', 'color': s:gui_colors.blue, 'term_color': s:term_colors.blue},
       \ 'rb': {'icon': '', 'color': s:gui_colors.red, 'term_color': s:term_colors.red},
       \ 'php': {'icon': '', 'color': s:gui_colors.purple, 'term_color': s:term_colors.purple},


### PR DESCRIPTION
# Overview

This pull request is a patch that displays a JavaScript icon when an .mjs file in defx.nvim.

# Reference

> https://github.com/ryanoasis/vim-devicons/issues/282
> https://github.com/ryanoasis/vim-devicons/pull/283

# ScreenShot

![Screenshot from 2019-09-14 02-28-31](https://user-images.githubusercontent.com/36619465/64882222-aa796900-d697-11e9-9ec9-6e57d29ab583.png)


