### PR TITLE
Add icon for Svelte

### DIFF
--- a/plugin/defx_icons.vim
+++ b/plugin/defx_icons.vim
@@ -174,6 +174,7 @@ let s:extensions = extend({
       \ 'webmanifest': {'icon': '', 'color': s:gui_colors.default, 'term_color': s:term_colors.default},
       \ 'webp': {'icon': '', 'color': s:gui_colors.aqua, 'term_color': s:term_colors.aqua},
       \ 'xcplayground': {'icon': '', 'color': s:gui_colors.orange, 'term_color': s:term_colors.orange},
+      \ 'svelte': {'icon': '', 'color': s:gui_colors.darkOrange, 'term_color': s:term_colors.darkOrange},
       \ }, get(g:, 'defx_icons_extensions', {}))
 
 let s:exact_matches = extend({


### PR DESCRIPTION
## Description

Adds icon for Svelte.

## Screenshot
<img width="127" alt="Screenshot of the Svelte icon with dark orange color" src="https://user-images.githubusercontent.com/10794501/130272529-083460b2-2d1b-4916-9456-d09b1f3ce68e.png">
